### PR TITLE
Dependencies cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,15 +10,9 @@ checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "basex-rs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c50147713f635888f61a089b99f4fd80345492f3c238181d2d7db78f44e9cf"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bech32"
@@ -383,7 +377,6 @@ name = "zeronet_cryptography"
 version = "0.1.8"
 dependencies = [
  "base64",
- "basex-rs",
  "bitcoin",
  "hex",
  "ripemd160",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,5 @@ ripemd160 = "~0.9.0"
 secp256k1 = { version = "~0.19.0", features = ["recovery", "rand", "std", "rand-std"] }
 base64 = "~0.12.0"
 sha2 = "~0.9.0"
-basex-rs = "~0.1.0"
 thiserror = "~1.0"
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "WTFPL"
 bitcoin = "~0.25"
 ripemd160 = "~0.9.0"
 secp256k1 = { version = "~0.19.0", features = ["recovery", "rand", "std", "rand-std"] }
-base64 = "~0.12.0"
+base64 = "~0.13.0"
 sha2 = "~0.9.0"
 thiserror = "~1.0"
 hex = "0.4.3"


### PR DESCRIPTION
basex_rs was useless and its work could be done with base58 from bitcoin crate and wif_to_privkey() function. So I removed it from the codebase.
Also, I updated the base64 crate to the latest version.